### PR TITLE
Schedule SDK tests

### DIFF
--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [ "master" ]
+  schedule:
+    - cron: '0 */6 * * *'
 
 jobs:
   run_sdk_tests:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Android SDK tests](https://github.com/extole/android/actions/workflows/sdk-test.yml/badge.svg?branch=master&event=schedule)](https://github.com/extole/android/actions/workflows/sdk-test.yml)
+
 # Extole Android SDK
 
 This app provides source code examples of how to:


### PR DESCRIPTION
This will schedule running SDK tests every 6 hours. Also adding a status badge to readme